### PR TITLE
Feature/networkmanager basedao

### DIFF
--- a/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabase.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabase.java
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase;
  * @author Riccardo De Zen
  * Abstract class to allow Room library to instantiate the database.
  */
-@Database(entities = {SMSEntity.class}, version = 1)
+@Database(entities = {SMSEntity.class}, version = 1, exportSchema = false)
 abstract class SMSDatabase extends RoomDatabase {
     public abstract SMSDao access();
 }

--- a/networkmanager/src/androidTest/java/com/dezen/riccardo/networkmanager/DictionaryDatabaseTest.java
+++ b/networkmanager/src/androidTest/java/com/dezen/riccardo/networkmanager/DictionaryDatabaseTest.java
@@ -64,7 +64,6 @@ public class DictionaryDatabaseTest {
         String address = "0";
         PeerEntity peer = new PeerEntity(address);
         dictionaryDatabase.access().addPeer(peer);
-        dictionaryDatabase.access().addPeer(peer);
         assertTrue(dictionaryDatabase.access().containsPeer(address));
     }
 

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/NetworkDictionary.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/NetworkDictionary.java
@@ -29,6 +29,9 @@ public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
     public static final String NETWORK_DICTIONARY_DATABASE_NAME = "NETWORK_DICTIONARY_DATABASE";
     public static final String NETWORK_DICTIONARY_PEER_TABLE_NAME = "peerentity";
     public static final String NETWORK_DICTIONARY_RESOURCE_TABLE_NAME = "resourceentity";
+    public static final String PEER_TABLE_ADDRESS_COLUMN_NAME = "address";
+    public static final String RESOURCE_TABLE_KEY_COLUMN_NAME = "key";
+    public static final String RESOURCE_TABLE_VALUE_COLUMN_NAME = "value";
 
     private Map<String, String> peers;
     private Map<String, String> resources;
@@ -381,7 +384,7 @@ public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
             List<StringResource> resourceList = new ArrayList<StringResource>();
             List<ResourceEntity> resourceEntities = dictionaryDatabase.access().getAllResources();
             for(ResourceEntity resource : resourceEntities)
-                resourceList.add(new StringResource(resource.keyName, resource.value));
+                resourceList.add(new StringResource(resource.key, resource.value));
             return resourceList;
         }
 

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/NetworkDictionary.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/NetworkDictionary.java
@@ -13,6 +13,7 @@ import com.dezen.riccardo.smshandler.SMSPeer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.Long.valueOf;
@@ -26,6 +27,8 @@ import static java.lang.Long.valueOf;
 public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
 
     public static final String NETWORK_DICTIONARY_DATABASE_NAME = "NETWORK_DICTIONARY_DATABASE";
+    public static final String NETWORK_DICTIONARY_PEER_TABLE_NAME = "peerentity";
+    public static final String NETWORK_DICTIONARY_RESOURCE_TABLE_NAME = "resourceentity";
 
     private Map<String, String> peers;
     private Map<String, String> resources;
@@ -331,13 +334,12 @@ public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
          * Returns an array containing all Peers. Peers are not copied singularly.
          * @return a list containing all Peers
          */
-        private SMSPeer[] getPeers() {
-            int numbersPeer = dictionaryDatabase.access().getAllPeers().length;
-            SMSPeer[] peerArray = new SMSPeer[numbersPeer];
-            PeerEntity[] peerEntities = dictionaryDatabase.access().getAllPeers();
-            for(int i=0; i<numbersPeer; i++)
-                peerArray[i] = new SMSPeer(peerEntities[i].address);
-            return peerArray;
+        private List<SMSPeer> getPeers() {
+            List<SMSPeer> peerList = new ArrayList<SMSPeer>();
+            List<PeerEntity> peerEntities = dictionaryDatabase.access().getAllPeers();
+            for(PeerEntity peer : peerEntities)
+                peerList.add(new SMSPeer(peer.address));
+            return peerList;
         }
 
         /**
@@ -375,13 +377,12 @@ public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
          * Returns an array containing all Resources. Resources are not copied singularly.
          * @return a list containing all Resources
          */
-        private StringResource[] getResources() {
-            int numbersResource = dictionaryDatabase.access().getAllResources().length;
-            StringResource[] resourceArray = new StringResource[numbersResource];
-            ResourceEntity[] resourceEntities = dictionaryDatabase.access().getAllResources();
-            for(int i=0; i<numbersResource; i++)
-                resourceArray[i] = new StringResource(resourceEntities[i].keyName, resourceEntities[i].value);
-            return resourceArray;
+        private List<StringResource> getResources() {
+            List<StringResource> resourceList = new ArrayList<StringResource>();
+            List<ResourceEntity> resourceEntities = dictionaryDatabase.access().getAllResources();
+            for(ResourceEntity resource : resourceEntities)
+                resourceList.add(new StringResource(resource.keyName, resource.value));
+            return resourceList;
         }
 
         /**
@@ -410,8 +411,8 @@ public class NetworkDictionary implements Dictionary<SMSPeer, StringResource> {
         protected Long doInBackground(NetworkDictionaryDatabase ... database)
         {
             for (NetworkDictionaryDatabase db: database) {
-                SMSPeer[] smsPeers = db.getPeers();
-                StringResource[] stringResources = db.getResources();
+                List<SMSPeer> smsPeers = db.getPeers();
+                List<StringResource> stringResources = db.getResources();
 
                 //Could this be done better?
                 // Maybe return the arrays so that maps are handled in main thread?

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
@@ -9,6 +9,8 @@ import androidx.room.Update;
 import androidx.sqlite.db.SimpleSQLiteQuery;
 import androidx.sqlite.db.SupportSQLiteQuery;
 
+import com.dezen.riccardo.networkmanager.NetworkDictionary;
+
 import java.util.List;
 
 /**
@@ -96,7 +98,7 @@ public abstract class BaseDao<P, R>{
      */
     public boolean containsPeer(String address){
         SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                COUNT_QUERY + getPeerTableName() +" WHERE address='"+address+"'"
+                COUNT_QUERY + getPeerTableName() +" WHERE "+NetworkDictionary.PEER_TABLE_ADDRESS_COLUMN_NAME+"='"+address+"'"
         );
         return performCount(query)!=0;
     }
@@ -107,33 +109,11 @@ public abstract class BaseDao<P, R>{
      */
     public boolean containsResource(String key){
         SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                COUNT_QUERY + getResourceTableName() +" WHERE keyName='"+key+"'"
+                COUNT_QUERY + getResourceTableName() +" WHERE "+ NetworkDictionary.RESOURCE_TABLE_KEY_COLUMN_NAME+" ='"+key+"'"
         );
         return performCount(query)!=0;
     }
 
-
-    /**
-     * @param address of peer
-     * @return peer with that address
-     */
-    public P getPeer(String address){
-        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                GET_ALL_QUERY + getResourceTableName() +" WHERE address='"+address+"'"
-        );
-        return performGetPeer(query);
-    }
-
-    /**
-     * @param key of resource
-     * @return resource with that key
-     */
-    public R getResource(String key){
-        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                GET_ALL_QUERY + getResourceTableName() +" WHERE keyName='"+key+"'"
-        );
-        return performGetResource(query);
-    }
 
     /**
      * Method to perform the query correctly through Room

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
@@ -1,0 +1,190 @@
+package com.dezen.riccardo.networkmanager.database_dictionary;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.RawQuery;
+import androidx.room.Update;
+import androidx.sqlite.db.SimpleSQLiteQuery;
+import androidx.sqlite.db.SupportSQLiteQuery;
+
+import java.util.List;
+
+/**
+ * Base class for a Dao accessing a table in a Room database.
+ * Any class extending this should be abstract and Override {@link #getPeerTableName()}, {@Link #getResourceTableName}
+ * Overriding anything else is unnecessary for full functionality.
+ * @author Giorgia Bortoletti
+ * @param <P> The Type of Peer Entity the Dao provides access to.
+ * @param <R> The Type of Resource Entity the Dao provides access to.
+ */
+@Dao
+public abstract class BaseDao<P, R>{
+
+    //Table name has to follow
+    protected static final String COUNT_QUERY = "SELECT COUNT(*) FROM ";
+
+    //Table name has to follow
+    protected static final String GET_ALL_QUERY = "SELECT * FROM ";
+
+    /**
+     * Add a new resource
+     * @param resourceEntities to add
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public abstract void addResource(R... resourceEntities);
+
+    /**
+     * Update a resource
+     * @param resourceEntities to update
+     */
+    @Update
+    public abstract void updateResource(R... resourceEntities);
+
+    /**
+     * Delete a resource
+     * @param resourceEntities to remove
+     */
+    @Delete
+    public abstract void removeResource(R... resourceEntities);
+
+    /**
+     * Add a new peer
+     * @param peerEntities to add
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public abstract void addPeer(P... peerEntities);
+
+    /**
+     * Update a peer
+     * @param peerEntities to update
+     */
+    @Update
+    public abstract void updatePeer(P... peerEntities);
+
+    /**
+     * Delete a peer
+     * @param peerEntities to remove
+     */
+    @Delete
+    public abstract void removePeer(P... peerEntities);
+
+    /**
+     * @return the number of peers rows in the table
+     */
+    public int countPeers(){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                COUNT_QUERY + getPeerTableName()
+        );
+        return performCount(query);
+    }
+
+    /**
+     * @return the number of resources rows in the table
+     */
+    public int countResources(){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                COUNT_QUERY + getResourceTableName()
+        );
+        return performCount(query);
+    }
+
+    /**
+     * @param address of peer to find
+     * @return true if database contains the peer
+     */
+    public boolean containsPeer(String address){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                COUNT_QUERY + getPeerTableName() +" WHERE address=:"+address
+        );
+        return performCount(query)!=0;
+    }
+
+    /**
+     * @param key of resource to find
+     * @return true if database contains the resource
+     */
+    public boolean containsResource(String key){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                COUNT_QUERY + getResourceTableName() +" WHERE keyName=:"+key
+        );
+        return performCount(query)!=0;
+    }
+
+
+    /**
+     * @param key of resource
+     * @return resource with that key
+     */
+    public R getResource(String key){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                COUNT_QUERY + getResourceTableName() +" WHERE keyName=:"+key
+        );
+        return performGetResource(query);
+    }
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return an int value returned by the query. In this case the number of rows in the table.
+     */
+    @RawQuery
+    protected abstract int performCount(SupportSQLiteQuery query);
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return an int value returned by the query. In this case the resource found.
+     */
+    @RawQuery
+    protected abstract R performGetResource(SupportSQLiteQuery query);
+
+    /**
+     * @return all the peers rows in the table
+     */
+    public List<P> getAllPeers(){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                GET_ALL_QUERY + getPeerTableName()
+        );
+        return performGetAllPeers(query);
+    }
+
+    /**
+     * @return all the resources rows in the table
+     */
+    public List<R> getAllResources(){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                GET_ALL_QUERY + getResourceTableName()
+        );
+        return performGetAllResources(query);
+    }
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return a List returned by the query. In this case all the peers rows in the table.
+     */
+    @RawQuery
+    protected abstract List<P> performGetAllPeers(SupportSQLiteQuery query);
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return a List returned by the query. In this case all the resources rows in the table.
+     */
+    @RawQuery
+    protected abstract List<R> performGetAllResources(SupportSQLiteQuery query);
+
+    /**
+     * Method to be overridden in order to find the name of the peer table.
+     * @return a String containing the name for the table this Dao provide access to.
+     */
+    public abstract String getPeerTableName();
+
+    /**
+     * Method to be overridden in order to find the name of the resource table.
+     * @return a String containing the name for the table this Dao provide access to.
+     */
+    public abstract String getResourceTableName();
+}

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/BaseDao.java
@@ -36,20 +36,6 @@ public abstract class BaseDao<P, R>{
     public abstract void addResource(R... resourceEntities);
 
     /**
-     * Update a resource
-     * @param resourceEntities to update
-     */
-    @Update
-    public abstract void updateResource(R... resourceEntities);
-
-    /**
-     * Delete a resource
-     * @param resourceEntities to remove
-     */
-    @Delete
-    public abstract void removeResource(R... resourceEntities);
-
-    /**
      * Add a new peer
      * @param peerEntities to add
      */
@@ -57,11 +43,25 @@ public abstract class BaseDao<P, R>{
     public abstract void addPeer(P... peerEntities);
 
     /**
+     * Update a resource
+     * @param resourceEntities to update
+     */
+    @Update
+    public abstract void updateResource(R... resourceEntities);
+
+    /**
      * Update a peer
      * @param peerEntities to update
      */
     @Update
     public abstract void updatePeer(P... peerEntities);
+
+    /**
+     * Delete a resource
+     * @param resourceEntities to remove
+     */
+    @Delete
+    public abstract void removeResource(R... resourceEntities);
 
     /**
      * Delete a peer
@@ -96,7 +96,7 @@ public abstract class BaseDao<P, R>{
      */
     public boolean containsPeer(String address){
         SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                COUNT_QUERY + getPeerTableName() +" WHERE address=:"+address
+                COUNT_QUERY + getPeerTableName() +" WHERE address='"+address+"'"
         );
         return performCount(query)!=0;
     }
@@ -107,11 +107,22 @@ public abstract class BaseDao<P, R>{
      */
     public boolean containsResource(String key){
         SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                COUNT_QUERY + getResourceTableName() +" WHERE keyName=:"+key
+                COUNT_QUERY + getResourceTableName() +" WHERE keyName='"+key+"'"
         );
         return performCount(query)!=0;
     }
 
+
+    /**
+     * @param address of peer
+     * @return peer with that address
+     */
+    public P getPeer(String address){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                GET_ALL_QUERY + getResourceTableName() +" WHERE address='"+address+"'"
+        );
+        return performGetPeer(query);
+    }
 
     /**
      * @param key of resource
@@ -119,7 +130,7 @@ public abstract class BaseDao<P, R>{
      */
     public R getResource(String key){
         SimpleSQLiteQuery query = new SimpleSQLiteQuery(
-                COUNT_QUERY + getResourceTableName() +" WHERE keyName=:"+key
+                GET_ALL_QUERY + getResourceTableName() +" WHERE keyName='"+key+"'"
         );
         return performGetResource(query);
     }
@@ -135,10 +146,18 @@ public abstract class BaseDao<P, R>{
     /**
      * Method to perform the query correctly through Room
      * @param query the query to be performed
-     * @return an int value returned by the query. In this case the resource found.
+     * @return R resource
      */
     @RawQuery
     protected abstract R performGetResource(SupportSQLiteQuery query);
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return P peer
+     */
+    @RawQuery
+    protected abstract P performGetPeer(SupportSQLiteQuery query);
 
     /**
      * @return all the peers rows in the table

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/DictionaryDao.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/DictionaryDao.java
@@ -7,92 +7,28 @@ import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import androidx.room.Update;
 
+import com.dezen.riccardo.networkmanager.NetworkDictionary;
+
 /**
  * @author Giorgia Bortoletti
+ * Class extending the BaseDao class for PeerEntity, ResourceEntity
  */
 @Dao
-public interface DictionaryDao {
-    public static final String databaseResource="resourceentity";
-    public static final String databasePeer="peerentity";
+public abstract class DictionaryDao extends BaseDao<PeerEntity, ResourceEntity>{
+    /**
+     * @return the name of the table containing the peer entities.
+     */
+    @Override
+    public String getPeerTableName(){
+        return NetworkDictionary.NETWORK_DICTIONARY_PEER_TABLE_NAME;
+    }
 
     /**
-     * Add a new resource
-     * @param resourceEntities to add
+     * @return the name of the table containing the resource entities.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    public void addResource(ResourceEntity... resourceEntities);
-
-    /**
-     * Update a resource
-     * @param resourceEntities to update
-     */
-    @Update
-    public void updateResource(ResourceEntity... resourceEntities);
-
-    /**
-     * Delete a resource
-     * @param resourceEntities to remove
-     */
-    @Delete
-    public void removeResource(ResourceEntity... resourceEntities);
-
-    /**
-     * Find and return only one resource with this key
-     * @param key of resource
-     * @return ResourceEntity
-     */
-    @Query("SELECT * FROM "+databaseResource+" WHERE keyName=:key")
-    public ResourceEntity getResource(String key);
-
-    /**
-     * Get all resources
-     * @return array of ResourceEntity
-     */
-    @Query("SELECT * FROM "+databaseResource)
-    public ResourceEntity[] getAllResources();
-
-    /**
-     * Verify if a Resource is in the database
-     * @param key of Resource to find
-     * @return true if database contains the resource
-     */
-    @Query("SELECT COUNT(*) FROM "+databaseResource+" WHERE keyName=:key")
-    public boolean containsResource(String key);
-
-    /**
-     * Add a new peer
-     * @param peerEntities to add
-     */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    public void addPeer(PeerEntity... peerEntities);
-
-    /**
-     * Update a peer
-     * @param peerEntities to update
-     */
-    @Update
-    public void updatePeer(PeerEntity... peerEntities);
-
-    /**
-     * Delete a peer
-     * @param peerEntities to remove
-     */
-    @Delete
-    public void removePeer(PeerEntity... peerEntities);
-
-    /**
-     * Get all peers
-     * @return array of PeerEntity
-     */
-    @Query("SELECT * FROM "+databasePeer)
-    public PeerEntity[] getAllPeers();
-
-    /**
-     * Verify if a Resource is in the database
-     * @param address of Peer to find
-     * @return true if database contains the peer
-     */
-    @Query("SELECT COUNT(*) FROM " +databasePeer+" WHERE address=:address")
-    public boolean containsPeer(String address);
-
+    @Override
+    public String getResourceTableName(){
+        return NetworkDictionary.NETWORK_DICTIONARY_RESOURCE_TABLE_NAME;
+    }
 }
+

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/DictionaryDao.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/DictionaryDao.java
@@ -6,8 +6,10 @@ import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import androidx.room.Update;
+import androidx.sqlite.db.SimpleSQLiteQuery;
 
 import com.dezen.riccardo.networkmanager.NetworkDictionary;
+import com.dezen.riccardo.smshandler.SMSPeer;
 
 /**
  * @author Giorgia Bortoletti
@@ -29,6 +31,28 @@ public abstract class DictionaryDao extends BaseDao<PeerEntity, ResourceEntity>{
     @Override
     public String getResourceTableName(){
         return NetworkDictionary.NETWORK_DICTIONARY_RESOURCE_TABLE_NAME;
+    }
+
+    /**
+     * @param address of peer
+     * @return peer with that address
+     */
+    public PeerEntity getPeer(String address){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                GET_ALL_QUERY + getResourceTableName() +" WHERE "+NetworkDictionary.PEER_TABLE_ADDRESS_COLUMN_NAME+"='"+address+"'"
+        );
+        return performGetPeer(query);
+    }
+
+    /**
+     * @param key of resource
+     * @return resource with that key
+     */
+    public ResourceEntity getResource(String key){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                GET_ALL_QUERY + getResourceTableName() +" WHERE "+ NetworkDictionary.RESOURCE_TABLE_KEY_COLUMN_NAME+" ='"+key+"'"
+        );
+        return performGetResource(query);
     }
 }
 

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/PeerEntity.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/PeerEntity.java
@@ -1,8 +1,11 @@
 package com.dezen.riccardo.networkmanager.database_dictionary;
 
 import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+
+import com.dezen.riccardo.networkmanager.NetworkDictionary;
 
 /**
  * @author Giorgia Bortoletti
@@ -17,5 +20,6 @@ public class PeerEntity {
         this.address = address;
     }
     @PrimaryKey @NonNull
+    @ColumnInfo (name = NetworkDictionary.PEER_TABLE_ADDRESS_COLUMN_NAME)
     public String address;
 }

--- a/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/ResourceEntity.java
+++ b/networkmanager/src/main/java/com/dezen/riccardo/networkmanager/database_dictionary/ResourceEntity.java
@@ -4,6 +4,9 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+
+import com.dezen.riccardo.networkmanager.NetworkDictionary;
+
 /**
  * @author Giorgia Bortoletti
  */
@@ -12,15 +15,16 @@ public class ResourceEntity {
 
     /**
      * Constructor of ResourceEntity
-     * @param keyName
+     * @param key
      * @param value
      */
-    public ResourceEntity(String keyName, String value) {
-        this.keyName = keyName;
+    public ResourceEntity(String key, String value) {
+        this.key = key;
         this.value = value;
     }
     @PrimaryKey @NonNull
-    public String keyName;
-    @ColumnInfo(name = "value")
+    @ColumnInfo(name = NetworkDictionary.RESOURCE_TABLE_KEY_COLUMN_NAME)
+    public String key;
+    @ColumnInfo(name = NetworkDictionary.RESOURCE_TABLE_VALUE_COLUMN_NAME)
     public String value;
 }


### PR DESCRIPTION
I added the BaseDao class to avoid hardwiring on DictionaryDao on Riccardo's suggestion. 
I let DictionaryDao entities as ResourceEntity and PeerEntity without transforming SmsPeer and StringResource into entities. If you tell me, I make SmsPeer and StringResource entities but then they must necessarily be used as database entities.