### PR TITLE
Added SMSDatabaseTest and an assignment mechanism of ID SMSMessage

### DIFF
--- a/lib/src/androidTest/java/com/dezen/riccardo/smshandler/SMSDatabaseTest.java
+++ b/lib/src/androidTest/java/com/dezen/riccardo/smshandler/SMSDatabaseTest.java
@@ -1,0 +1,78 @@
+package com.dezen.riccardo.smshandler;
+
+import android.content.Context;
+
+import androidx.room.Room;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.dezen.riccardo.smshandler.database.SMSDao;
+import com.dezen.riccardo.smshandler.database.SMSDatabase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * @author Giorgia Bortoletti
+ */
+@RunWith(AndroidJUnit4.class)
+public class SMSDatabaseTest {
+
+    private SMSDatabase smsDatabase;
+    private String bodyMessage = "text";
+    private String addressPeer = "+39892424";
+    private int idMessage;
+    private SMSPeer peer;
+
+    @Before
+    public void createDb() {
+        Context context = ApplicationProvider.getApplicationContext();
+        smsDatabase = Room.inMemoryDatabaseBuilder(context, SMSDatabase.class).build();
+        idMessage = 0;
+        peer = new SMSPeer(addressPeer);
+    }
+
+    @After
+    public void closeDb() throws IOException {
+        smsDatabase.close();
+    }
+
+    @Test
+    public void insert() {
+        SMSMessage message = new SMSMessage(peer, bodyMessage);
+        SMSDao dbAccess = smsDatabase.access();
+        int countPrec = dbAccess.count();
+        dbAccess.insert(message);
+        assertEquals(countPrec+1 , dbAccess.count());
+    }
+
+    @Test
+    public void update() {
+        SMSMessage message = new SMSMessage(peer, bodyMessage);
+        SMSDao dbAccess = smsDatabase.access();
+        dbAccess.insert(message);
+        String newBody = bodyMessage+"56";
+        message.setData(newBody);
+        dbAccess.update(message);
+        List<SMSMessage> list = dbAccess.getAll();
+        assertEquals(newBody, list.get(list.size()-1).getData());
+    }
+
+    @Test
+    public void delete() {
+        SMSMessage message = new SMSMessage(peer, bodyMessage);
+        SMSDao dbAccess = smsDatabase.access();
+        dbAccess.insert(message);
+        int countPrec = dbAccess.count();
+        dbAccess.delete(message);
+        assertEquals(countPrec-1, dbAccess.count());
+    }
+}
+

--- a/lib/src/main/java/com/dezen/riccardo/smshandler/SMSMessage.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/SMSMessage.java
@@ -20,6 +20,7 @@ public class SMSMessage extends Message<String, SMSPeer>{
 
     //Name of the Entity table inside the Database.
     public static final String SMS_TABLE_NAME = "smsmessage";
+    public static final String SMS_ID_COLUMN_NAME = "id";
     public static final String SMS_ADDRESS_COLUMN_NAME = "address";
     public static final String SMS_BODY_COLUMN_NAME = "message";
 
@@ -29,7 +30,8 @@ public class SMSMessage extends Message<String, SMSPeer>{
     public static final int MAX_MESSAGE_LENGTH = 160;
 
     //The id is currently only relevant inside the database and does not need to be seen or set outside
-    @PrimaryKey(autoGenerate = true)
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo (name = SMS_ID_COLUMN_NAME)
     private int id;
     @ColumnInfo(name = SMS_ADDRESS_COLUMN_NAME)
     private SMSPeer peer;
@@ -78,11 +80,11 @@ public class SMSMessage extends Message<String, SMSPeer>{
     }
 
     /**
-     * Setter for the id
-     * @param newId the new Id for this Message
+     * Setter for the data
+     * @param newData the new Data for this Message
      */
-    public void setId(int newId){
-        id = newId;
+    public void setData(String newData){
+        data = newData;
     }
 
     /**
@@ -91,6 +93,14 @@ public class SMSMessage extends Message<String, SMSPeer>{
     @Override
     public String getData() {
         return data;
+    }
+
+    /**
+     * Setter for the id
+     * @param newId the new Id for this Message
+     */
+    public void setId(int newId){
+        id = newId;
     }
 
     /**
@@ -128,7 +138,7 @@ public class SMSMessage extends Message<String, SMSPeer>{
      */
     @NonNull
     public String toString(){
-        return "Peer: "+peer.toString()+"\nData: "+data;
+        return "Id: "+id+"\nPeer: "+peer.toString()+"\nData: "+data;
     }
 
     /**

--- a/lib/src/main/java/com/dezen/riccardo/smshandler/database/BaseDao.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/database/BaseDao.java
@@ -9,6 +9,9 @@ import androidx.room.Update;
 import androidx.sqlite.db.SimpleSQLiteQuery;
 import androidx.sqlite.db.SupportSQLiteQuery;
 
+import com.dezen.riccardo.smshandler.SMSHandler;
+import com.dezen.riccardo.smshandler.SMSMessage;
+
 import java.util.List;
 
 /**
@@ -23,7 +26,8 @@ public abstract class BaseDao<T>{
 
     //Table name has to follow
     protected static final String COUNT_QUERY = "SELECT COUNT(*) FROM ";
-
+    //Table name has to follow
+    protected static final String MAX_QUERY = "SELECT MAX("+SMSMessage.SMS_ID_COLUMN_NAME+") FROM ";
     //Table name has to follow
     protected static final String GET_ALL_QUERY = "SELECT * FROM ";
 
@@ -65,6 +69,24 @@ public abstract class BaseDao<T>{
      */
     @RawQuery
     protected abstract int performCount(SupportSQLiteQuery query);
+
+    /**
+     * @return the number of rows in the table
+     */
+    public int maxId(){
+        SimpleSQLiteQuery query = new SimpleSQLiteQuery(
+                MAX_QUERY + getTableName()
+        );
+        return performMax(query);
+    }
+
+    /**
+     * Method to perform the query correctly through Room
+     * @param query the query to be performed
+     * @return an int value returned by the query. In this case the number of rows in the table.
+     */
+    @RawQuery
+    protected abstract int performMax(SupportSQLiteQuery query);
 
     /**
      * @return all the rows in the table

--- a/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDao.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDao.java
@@ -1,6 +1,9 @@
 package com.dezen.riccardo.smshandler.database;
 
 import androidx.room.Dao;
+import androidx.room.RawQuery;
+import androidx.sqlite.db.SimpleSQLiteQuery;
+import androidx.sqlite.db.SupportSQLiteQuery;
 
 import com.dezen.riccardo.smshandler.SMSMessage;
 
@@ -9,7 +12,7 @@ import com.dezen.riccardo.smshandler.SMSMessage;
  * Interface extending the BaseDao class for SMSMessage
  */
 @Dao
-abstract class SMSDao extends BaseDao<SMSMessage>{
+public abstract class SMSDao extends BaseDao<SMSMessage>{
     /**
      * @return the name of the table containing the SMSMessage entities.
      */

--- a/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabase.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabase.java
@@ -12,6 +12,6 @@ import com.dezen.riccardo.smshandler.SMSMessage;
  */
 @Database(entities = {SMSMessage.class}, version = 1)
 @TypeConverters({SMSConverters.class})
-abstract class SMSDatabase extends RoomDatabase {
+public abstract class SMSDatabase extends RoomDatabase {
     public abstract SMSDao access();
 }

--- a/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabaseManager.java
+++ b/lib/src/main/java/com/dezen/riccardo/smshandler/database/SMSDatabaseManager.java
@@ -9,6 +9,7 @@ import androidx.room.Room;
 
 import com.dezen.riccardo.smshandler.ReceivedMessageListener;
 import com.dezen.riccardo.smshandler.SMSMessage;
+import com.dezen.riccardo.smshandler.SMSPeer;
 
 import java.util.List;
 
@@ -21,6 +22,8 @@ import java.util.List;
  * @author Riccardo De Zen
  */
 public class SMSDatabaseManager {
+
+    private static int lastIdMessage;
 
     private static final String CON_ERROR = "This class uses the singleton design pattern. Use getInstance() to get a reference to the single instance of this class";
     private static final String UNREAD_SMS_DB_NAME = "unread-sms-db";
@@ -50,6 +53,7 @@ public class SMSDatabaseManager {
                     .allowMainThreadQueries()
                     .build();
         }
+        lastIdMessage = maxId();
     }
 
     /**
@@ -87,6 +91,13 @@ public class SMSDatabaseManager {
     }
 
     /**
+     * @return the maximum id of SMS Message
+     */
+    private int maxId(){
+        return database.access().maxId();
+    }
+
+    /**
      * Method to add one or more SMS to the database, runs on the main Thread
      * @param newMessages the message/messages to be added
      */
@@ -103,7 +114,8 @@ public class SMSDatabaseManager {
         if (newMessages == null || newMessages.length <= 0) return;
         SMSMessage[] messages = new SMSMessage[newMessages.length];
         for (int i = 0; i < newMessages.length; i++) {
-            messages[i] = new SMSMessage(newMessages[i]);
+            messages[i] = new SMSMessage(lastIdMessage++, new SMSPeer(newMessages[i].getOriginatingAddress()),
+                    newMessages[i].getMessageBody());
         }
         addSMS(messages);
     }


### PR DESCRIPTION
Auto-generate ID SMSMessage creates problems in update and delete so I had implemented an assignment mechanism of ID (adding +1 at the last ID assigned).

Short description:
Writing the tests I realized that having the autogenerated SMSMessage ID creates problems in update and delete.
Update because when we want to update we can neither create a new message with the same id (the database changes id seeing the conflict) and message.setData doesn't work because it doesn't update the entity but only the data in the class.
Delete I don't know exactly what the problem is but it is as if it could not find the message in the database even though it has been inserted.
In this pull request I put SMSDatabaseTest and a management of the assignment of the id without autogeneration. The test remains valid also for the case of autogenerated id but it fails.